### PR TITLE
fix(core): get latest output without id

### DIFF
--- a/examples/news.ycombinator.com.ts
+++ b/examples/news.ycombinator.com.ts
@@ -1,0 +1,54 @@
+import Hero from '@ulixee/hero';
+import Databox from '@ulixee/databox';
+
+export default new Databox(async databox => {
+  const hero = new Hero({ databox });
+  await hero.goto('https://news.ycombinator.com/');
+  await hero.waitForPaintingStable();
+
+  const stories = await hero.document.querySelectorAll('.athing');
+  const records = databox.output;
+  let lastStory;
+
+  for (const story of stories) {
+    const extraElem = await story.nextElementSibling;
+    records.push({});
+    const record = records[records.length - 1];
+
+    const titleElem = await story.querySelector('a.storylink');
+
+    record.score = parseInt(
+      await extraElem.querySelector('.score').textContent.catch(() => '0'),
+      10,
+    );
+    record.id = await story.getAttribute('id');
+    record.age = await extraElem.querySelector('.age a').textContent;
+    record.title = await titleElem.textContent;
+    const contributor = await extraElem.querySelector('.hnuser').textContent.catch(() => '');
+    record.contributor = { id: contributor, username: contributor };
+
+    const links = [...(await extraElem.querySelectorAll('.subtext > a'))];
+    const commentsLink = links[links.length - 1];
+    const commentText = await commentsLink.textContent;
+    record.commentCount = commentText.includes('comment')
+      ? parseInt(commentText.trim().match(/(\d+)\s/)[0], 10)
+      : 0;
+
+    lastStory = commentsLink;
+    record.url = await titleElem.getAttribute('href');
+  }
+
+  if (lastStory) {
+    await hero.click(lastStory);
+    await hero.waitForLocation('change');
+    await hero.waitForElement(hero.document.querySelector('textarea'));
+    await hero.click(hero.document.querySelector('textarea'));
+    await hero.type('Hackernews!');
+    const comments = [...(await hero.document.querySelectorAll('.commtext'))];
+    await hero.interact({
+      move: comments[comments.length - 1],
+    });
+  }
+
+  await hero.close();
+});

--- a/examples/ulixee.org.ts
+++ b/examples/ulixee.org.ts
@@ -1,0 +1,27 @@
+import Hero from '@ulixee/hero';
+import Databox from '@ulixee/databox';
+
+export default new Databox(async databox => {
+  const { input, output } = databox;
+  input.url ??= 'https://ulixee.org';
+
+  const hero = new Hero({ databox });
+
+  await hero.goto('https://ulixee.org');
+
+  const { document } = hero;
+  await document.querySelector('h1').textContent;
+
+  // // step 1 - look in dom
+  // const datasets = await document.querySelectorAll('.datasets .title');
+  //
+  // // step 2 - start collecting datasets
+  // output.datasets = [];
+  // for (const dataset of datasets) {
+  //   output.datasets.push(await dataset.textContent);
+  // }
+  //
+  // // step 3 - look at the first one
+  // await hero.click(datasets[0]);
+  // await hero.waitForLocation('change');
+});

--- a/fullstack/test/rebuildOutput.test.ts
+++ b/fullstack/test/rebuildOutput.test.ts
@@ -11,7 +11,7 @@ describe('basic OutputRebuilder tests', () => {
     const observable = new ObjectObserver(new Output());
 
     const clientOutput = observable.proxy;
-    const replayOutput = new OutputRebuilder(true);
+    const replayOutput = new OutputRebuilder();
     let id = 0;
     observable.onChanges = changes => {
       const changesToRecord = changes.map(change => ({
@@ -57,11 +57,11 @@ describe('basic OutputRebuilder tests', () => {
     expect(replayOutput.getLatestSnapshot(id).output).toEqual(clientOutput.toJSON());
   });
 
-  it('should be able to track the latest state of an output snapshot', async () => {
+  it('should be able to get the latest state of an output snapshot', async () => {
     const observable = new ObjectObserver(new Output());
 
     const clientOutput = observable.proxy;
-    const replayOutput = new OutputRebuilder(false);
+    const replayOutput = new OutputRebuilder();
     let id = 1;
     observable.onChanges = changes => {
       const changesToRecord = changes.map(change => ({


### PR DESCRIPTION
Output rebuilder can get the latest changeset without knowing the latest externalId